### PR TITLE
fix: update npm to 6.14.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,55 +1574,61 @@
       }
     },
     "npm": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
-      "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
+      "version": "6.14.9",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.9.tgz",
+      "integrity": "sha512-yHi1+i9LyAZF1gAmgyYtVk+HdABlLy94PMIDoK1TRKWvmFQAt5z3bodqVwKvzY0s6dLqQPVsRLiwhJfNtiHeCg==",
       "requires": {
-        "JSONStream": "^1.3.4",
+        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
+        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.2.0",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "ci-info": "^1.4.0",
+        "bin-links": "^1.1.8",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
-        "cmd-shim": "~2.0.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
+        "config-chain": "^1.1.12",
         "debuglog": "*",
         "detect-indent": "~5.0.0",
         "detect-newline": "^2.1.0",
         "dezalgo": "~1.0.3",
         "editor": "~1.0.0",
-        "figgy-pudding": "^3.4.1",
+        "figgy-pudding": "^3.5.1",
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
+        "gentle-fs": "^2.3.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
+        "hosted-git-info": "^2.8.8",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
+        "inherits": "^2.0.4",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
+        "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.2",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
+        "libcipm": "^4.0.8",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.4",
+        "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -1635,71 +1641,70 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
-        "meant": "~1.0.1",
+        "lru-cache": "^5.1.1",
+        "meant": "^1.0.2",
         "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
+        "mkdirp": "^0.5.5",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
+        "node-gyp": "^5.1.0",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.3",
         "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.1.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.11",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.6.0",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.5",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.7",
+        "npm-user-validate": "^1.0.1",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
-        "opener": "^1.5.0",
+        "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
+        "pacote": "^9.5.12",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
+        "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
+        "read-package-json": "^2.1.1",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
         "request": "^2.88.0",
         "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
+        "rimraf": "^2.7.1",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.6",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
         "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
+        "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
+        "uuid": "^3.3.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.3.0"
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -1711,27 +1716,17 @@
           "bundled": true
         },
         "agent-base": {
-          "version": "4.2.0",
+          "version": "4.3.0",
           "bundled": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
-          "version": "3.4.1",
+          "version": "3.5.2",
           "bundled": true,
           "requires": {
             "humanize-ms": "^1.2.1"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-align": {
@@ -1761,7 +1756,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.2.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "archy": {
@@ -1774,6 +1769,28 @@
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "asap": {
@@ -1816,25 +1833,19 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
+          "version": "1.1.8",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.3.0",
+            "graceful-fs": "^4.1.15",
+            "npm-normalize-package-bin": "^1.0.0",
             "write-file-atomic": "^2.3.0"
           }
         },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
         "bluebird": {
-          "version": "3.5.1",
+          "version": "3.5.5",
           "bundled": true
         },
         "boxen": {
@@ -1862,10 +1873,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true
@@ -1875,31 +1882,32 @@
           "bundled": true
         },
         "byte-size": {
-          "version": "4.0.3",
+          "version": "5.0.1",
           "bundled": true
         },
         "cacache": {
-          "version": "11.2.0",
+          "version": "12.0.3",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.3",
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
           }
         },
         "call-limit": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
         "camelcase": {
@@ -1924,15 +1932,15 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.4",
           "bundled": true
         },
         "ci-info": {
-          "version": "1.4.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "cidr-regex": {
-          "version": "2.0.9",
+          "version": "2.0.10",
           "bundled": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -1951,7 +1959,7 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "bundled": true,
           "requires": {
             "colors": "^1.1.2",
@@ -1960,23 +1968,36 @@
           }
         },
         "cliui": {
-          "version": "4.1.0",
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "3.0.0",
+              "version": "4.1.0",
               "bundled": true
             },
-            "strip-ansi": {
-              "version": "4.0.0",
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -1986,16 +2007,12 @@
           "bundled": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "mkdirp": "~0.5.0"
           }
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -2013,7 +2030,7 @@
           "bundled": true
         },
         "colors": {
-          "version": "1.1.2",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true
         },
@@ -2044,10 +2061,32 @@
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "config-chain": {
-          "version": "1.1.11",
+          "version": "1.1.12",
           "bundled": true,
           "requires": {
             "ini": "^1.3.4",
@@ -2055,10 +2094,10 @@
           }
         },
         "configstore": {
-          "version": "3.1.2",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
+            "dot-prop": "^4.2.1",
             "graceful-fs": "^4.1.2",
             "make-dir": "^1.0.0",
             "unique-string": "^1.0.0",
@@ -2082,6 +2121,10 @@
             "run-queue": "^1.0.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "iferr": {
               "version": "0.1.5",
               "bundled": true
@@ -2106,6 +2149,20 @@
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
           }
         },
         "crypto-random-string": {
@@ -2149,7 +2206,7 @@
           "bundled": true
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true
         },
         "defaults": {
@@ -2157,6 +2214,13 @@
           "bundled": true,
           "requires": {
             "clone": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -2184,7 +2248,7 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -2206,6 +2270,28 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "ecc-jsbn": {
@@ -2219,6 +2305,10 @@
         },
         "editor": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
           "bundled": true
         },
         "encoding": {
@@ -2235,6 +2325,10 @@
             "once": "^1.4.0"
           }
         },
+        "env-paths": {
+          "version": "2.2.0",
+          "bundled": true
+        },
         "err-code": {
           "version": "1.1.2",
           "bundled": true
@@ -2246,8 +2340,28 @@
             "prr": "~1.0.1"
           }
         },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
         "es6-promise": {
-          "version": "4.2.4",
+          "version": "4.2.8",
           "bundled": true
         },
         "es6-promisify": {
@@ -2272,6 +2386,12 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
           }
         },
         "extend": {
@@ -2282,28 +2402,17 @@
           "version": "1.3.0",
           "bundled": true
         },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "bundled": true
-        },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
           "bundled": true
         },
         "figgy-pudding": {
-          "version": "3.4.1",
+          "version": "3.5.1",
           "bundled": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
         },
         "flush-write-stream": {
           "version": "1.0.3",
@@ -2311,6 +2420,28 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "forever-agent": {
@@ -2332,13 +2463,45 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "fs-vacuum": {
@@ -2363,6 +2526,26 @@
             "iferr": {
               "version": "0.1.5",
               "bundled": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
         },
@@ -2370,15 +2553,9 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
@@ -2394,6 +2571,10 @@
             "wide-align": "^1.1.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -2406,23 +2587,30 @@
           }
         },
         "genfun": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
+            "cmd-shim": "^3.0.3",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
             "slide": "^1.1.6"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "iferr": {
               "version": "0.1.5",
               "bundled": true
@@ -2430,12 +2618,15 @@
           }
         },
         "get-caller-file": {
-          "version": "1.0.2",
+          "version": "2.0.5",
           "bundled": true
         },
         "get-stream": {
-          "version": "3.0.0",
-          "bundled": true
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "getpass": {
           "version": "0.1.7",
@@ -2445,7 +2636,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.6",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2478,10 +2669,16 @@
             "timed-out": "^4.0.0",
             "unzip-response": "^2.0.1",
             "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
+          "version": "4.2.4",
           "bundled": true
         },
         "har-schema": {
@@ -2489,15 +2686,46 @@
           "bundled": true
         },
         "har-validator": {
-          "version": "5.1.0",
+          "version": "5.1.5",
           "bundled": true,
           "requires": {
-            "ajv": "^5.3.0",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.12.6",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
           "bundled": true
         },
         "has-unicode": {
@@ -2505,7 +2733,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.7.1",
+          "version": "2.8.8",
           "bundled": true
         },
         "http-cache-semantics": {
@@ -2530,10 +2758,10 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.1",
+          "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "agent-base": "^4.1.0",
+            "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
         },
@@ -2556,7 +2784,7 @@
           "bundled": true
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -2570,6 +2798,10 @@
           "version": "0.1.4",
           "bundled": true
         },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true
+        },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
@@ -2579,7 +2811,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -2600,10 +2832,6 @@
             "validate-npm-package-name": "^3.0.0"
           }
         },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "ip": {
           "version": "1.1.5",
           "bundled": true
@@ -2612,26 +2840,33 @@
           "version": "2.1.0",
           "bundled": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
         },
         "is-ci": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "^1.5.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true
+            }
           }
         },
         "is-cidr": {
-          "version": "2.0.6",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "^2.0.10"
           }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -2667,13 +2902,27 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
         "is-retry-allowed": {
-          "version": "1.1.0",
+          "version": "1.2.0",
           "bundled": true
         },
         "is-stream": {
           "version": "1.1.0",
           "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -2702,10 +2951,6 @@
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
           "bundled": true
         },
         "json-stringify-safe": {
@@ -2737,56 +2982,163 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
         "libcipm": {
-          "version": "2.0.2",
+          "version": "4.0.8",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.2",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.1.0",
             "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^2.0.3",
+            "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
+            "pacote": "^9.1.0",
             "read-package-json": "^2.0.13",
             "rimraf": "^2.6.2",
             "worker-farm": "^1.6.0"
           }
         },
-        "libnpmhook": {
-          "version": "4.0.1",
+        "libnpm": {
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.2",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.5.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
           },
           "dependencies": {
-            "npm-registry-fetch": {
-              "version": "3.1.1",
+            "find-up": {
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "locate-path": "^3.0.0"
               }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true
             }
           }
         },
+        "libnpmhook": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
         "libnpx": {
-          "version": "10.2.0",
+          "version": "10.2.4",
           "bundled": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -2796,22 +3148,14 @@
             "update-notifier": "^2.3.0",
             "which": "^1.3.0",
             "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "yargs": "^14.2.3"
           }
         },
         "lock-verify": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
+            "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
         },
@@ -2886,11 +3230,10 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.3",
+          "version": "5.1.1",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
@@ -2901,15 +3244,15 @@
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.1",
+          "version": "5.0.2",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
+            "cacache": "^12.0.0",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
+            "https-proxy-agent": "^2.2.3",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
             "promise-retry": "^1.1.1",
@@ -2918,15 +3261,8 @@
           }
         },
         "meant": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
         },
         "mime-db": {
           "version": "1.35.0",
@@ -2939,10 +3275,6 @@
             "mime-db": "~1.35.0"
           }
         },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true
-        },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
@@ -2951,28 +3283,24 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true
         },
-        "minipass": {
-          "version": "2.3.3",
+        "minizlib": {
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -2992,10 +3320,16 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.5",
           "bundled": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true
+            }
           }
         },
         "move-concurrently": {
@@ -3008,6 +3342,12 @@
             "mkdirp": "^0.5.1",
             "rimraf": "^2.5.4",
             "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "ms": {
@@ -3028,47 +3368,24 @@
           }
         },
         "node-gyp": {
-          "version": "3.8.0",
+          "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
-          },
-          "dependencies": {
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              }
-            }
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.0",
+            "rimraf": "^2.6.3",
+            "semver": "^5.7.1",
+            "tar": "^4.4.12",
+            "which": "^1.3.1"
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "requires": {
             "abbrev": "1",
@@ -3076,17 +3393,26 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
           }
         },
         "npm-audit-report": {
-          "version": "1.3.1",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -3094,27 +3420,30 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
-          "bundled": true
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
           "bundled": true
         },
         "npm-install-checks": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
-          "version": "2.1.0",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.8.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
@@ -3126,175 +3455,63 @@
           "version": "1.2.1",
           "bundled": true
         },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "npm-package-arg": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
+            "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
-            "semver": "^5.5.0",
+            "semver": "^5.6.0",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.1.11",
+          "version": "1.4.8",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "2.1.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
+            "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
             "semver": "^5.4.1"
           }
         },
         "npm-profile": {
-          "version": "3.0.2",
+          "version": "4.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.6.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "1.1.0",
+          "version": "4.0.7",
           "bundled": true,
           "requires": {
+            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
-            "cacache": {
-              "version": "10.0.4",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-              },
-              "dependencies": {
-                "mississippi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
-                  }
-                }
-              }
-            },
-            "figgy-pudding": {
-              "version": "2.0.1",
+            "safe-buffer": {
+              "version": "5.2.1",
               "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
-              }
-            },
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "smart-buffer": {
-              "version": "1.1.15",
-              "bundled": true
-            },
-            "socks": {
-              "version": "1.1.10",
-              "bundled": true,
-              "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
-              }
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
             }
           }
         },
@@ -3306,7 +3523,7 @@
           }
         },
         "npm-user-validate": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "npmlog": {
@@ -3331,6 +3548,18 @@
           "version": "4.1.1",
           "bundled": true
         },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
         "once": {
           "version": "1.4.0",
           "bundled": true,
@@ -3339,21 +3568,12 @@
           }
         },
         "opener": {
-          "version": "1.5.0",
+          "version": "1.5.1",
           "bundled": true
         },
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
         },
         "os-tmpdir": {
           "version": "1.0.2",
@@ -3371,24 +3591,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "package-json": {
           "version": "4.0.1",
           "bundled": true,
@@ -3400,34 +3602,49 @@
           }
         },
         "pacote": {
-          "version": "8.1.6",
+          "version": "9.5.12",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
+            "bluebird": "^3.5.3",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
+            "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
+            "npm-normalize-package-bin": "^1.0.0",
             "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
+            "protoduck": "^5.0.1",
             "rimraf": "^2.6.2",
             "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.10",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "parallel-transform": {
@@ -3437,6 +3654,28 @@
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
             "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -3453,6 +3692,10 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
           "bundled": true
         },
         "performance-now": {
@@ -3501,10 +3744,10 @@
           "bundled": true
         },
         "protoduck": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "^5.0.0"
           }
         },
         "prr": {
@@ -3559,10 +3802,11 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.1.0",
+          "version": "6.8.2",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
@@ -3571,19 +3815,13 @@
           "bundled": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
           }
         },
         "read": {
@@ -3594,7 +3832,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
+          "version": "1.0.5",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -3614,42 +3852,36 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
             "glob": "^7.1.1",
             "graceful-fs": "^4.1.2",
             "json-parse-better-errors": "^1.0.1",
             "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "npm-normalize-package-bin": "^1.0.0"
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
+          "version": "5.3.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
             "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -3659,7 +3891,7 @@
           }
         },
         "registry-auth-token": {
-          "version": "3.3.2",
+          "version": "3.4.0",
           "bundled": true,
           "requires": {
             "rc": "^1.1.6",
@@ -3704,7 +3936,7 @@
           "bundled": true
         },
         "require-main-filename": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true
         },
         "resolve-from": {
@@ -3716,10 +3948,10 @@
           "bundled": true
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "run-queue": {
@@ -3727,6 +3959,12 @@
           "bundled": true,
           "requires": {
             "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "safe-buffer": {
@@ -3738,7 +3976,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "semver-diff": {
@@ -3753,11 +3991,10 @@
           "bundled": true
         },
         "sha": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
@@ -3775,32 +4012,37 @@
           "version": "3.0.2",
           "bundled": true
         },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "slide": {
           "version": "1.1.6",
           "bundled": true
         },
         "smart-buffer": {
-          "version": "4.0.1",
+          "version": "4.1.0",
           "bundled": true
         },
         "socks": {
-          "version": "2.2.0",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
           }
         },
         "sorted-object": {
@@ -3864,7 +4106,11 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
+          "version": "3.0.5",
+          "bundled": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
           "bundled": true
         },
         "sshpk": {
@@ -3883,8 +4129,11 @@
           }
         },
         "ssri": {
-          "version": "6.0.0",
-          "bundled": true
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
         },
         "stream-each": {
           "version": "1.2.2",
@@ -3900,6 +4149,28 @@
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "stream-shift": {
@@ -3936,14 +4207,20 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true
+            }
           }
         },
         "stringify-package": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "strip-ansi": {
@@ -3969,21 +4246,25 @@
           }
         },
         "tar": {
-          "version": "4.4.6",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
           }
         },
@@ -4008,6 +4289,28 @@
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "timed-out": {
@@ -4051,7 +4354,7 @@
           "bundled": true
         },
         "unique-filename": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -4095,6 +4398,19 @@
             "xdg-basedir": "^3.0.0"
           }
         },
+        "uri-js": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
@@ -4110,8 +4426,15 @@
           "version": "1.0.3",
           "bundled": true
         },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
         "uuid": {
-          "version": "3.3.2",
+          "version": "3.3.3",
           "bundled": true
         },
         "validate-npm-package-license": {
@@ -4175,34 +4498,50 @@
           }
         },
         "widest-line": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
             "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
-          "version": "2.1.0",
+          "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
             "string-width": {
-              "version": "1.0.2",
+              "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -4212,7 +4551,7 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.3.0",
+          "version": "2.4.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -4233,38 +4572,97 @@
           "bundled": true
         },
         "yallist": {
-          "version": "2.1.2",
+          "version": "3.0.3",
           "bundled": true
         },
         "yargs": {
-          "version": "11.0.0",
+          "version": "14.2.3",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
           },
           "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
+            "ansi-regex": {
+              "version": "4.1.0",
               "bundled": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
             }
           }
         },
         "yargs-parser": {
-          "version": "9.0.2",
+          "version": "15.0.1",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "bundled": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@oclif/plugin-help": "^2.1.4",
     "cli-ux": "^4.9.3",
     "lodash": "^4.17.11",
-    "npm": "6.4.1",
+    "npm": "^6.14.9",
     "read-package-tree": "^5.2.1",
     "semver": "^5.6.0"
   },


### PR DESCRIPTION
We need to update `npm` as on older versions, there is an issue with how it interacts
with `graceful-fs`, manifesting in an esoteric error of `TypeError: cb.apply is not a function`.

#### Changes Made
 - Update `npm`

#### Potential Risks
 - No significant risks.

#### Test Plan
 - Run new version locally in a repo known to be impacted by this issue.

#### Checklist
- ~[ ] I've increased test coverage~
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
